### PR TITLE
Opentezos and baking tools

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,6 +48,8 @@ You too can support this list and <strong>The Tezos Community</strong> directly 
 -   [Media](#media)
     -   [News](#news)
 -   [Block Explorers](#block-explorers)
+-   [Documentation](#documentation)
+-   [Baking Tools](#baking-tools)
 -   [Contribute](#contribute)
 
 ## Wallets
@@ -107,6 +109,15 @@ You too can support this list and <strong>The Tezos Community</strong> directly 
 
 -   [tzkt](https://tzkt.io/)
 -   [tzStats](https://tzstats.com/)
+
+## Documentation
+
+-   [Octez and Protocol Documentation](https://tezos.gitlab.io/introduction/tezos.html)
+-   [Open Tezos](https://opentezos.com/)
+
+## Baking Tools
+
+-   [Tez Capital](https://docs.tez.capital/)
 
 ## Contribute
 

--- a/readme.md
+++ b/readme.md
@@ -118,6 +118,7 @@ You too can support this list and <strong>The Tezos Community</strong> directly 
 ## Baking Tools
 
 -   [Tez Capital](https://docs.tez.capital/)
+-   [La Boulange](https://github.com/LaBoulange/tezos-baker/)
 
 ## Contribute
 


### PR DESCRIPTION
Two commits:
- Documentation: Official Octez & Protocol and Open Tezos + Baking Tools: Tez Capital
-  Baking Tools: La Boulange (kept in a separate commit so that it's easy to just merge the first, we're do not pretend to be "awesome" :-) )

All links were checked.
Layout was checked.